### PR TITLE
Fix scrollvid download URL

### DIFF
--- a/vidrun-install.sh
+++ b/vidrun-install.sh
@@ -7,7 +7,11 @@ set -euo pipefail
 # - Configures Nginx to serve that folder
 # - Installs scrollvid.sh into /usr/local/bin (PATH) and makes it executable
 
-REPO_SCROLLVID_URL="https://raw.githubusercontent.com/wilson1442/vidrun/refs/heads/main/scrollvid.sh"
+# The raw GitHub URL must use the branch name directly ("/main/...")
+# rather than the full ref path ("/refs/heads/main/..."). The latter
+# 404s, which caused v4 of the installer to fall back to the placeholder
+# wrapper script instead of installing the real scrollvid.sh.
+REPO_SCROLLVID_URL="https://raw.githubusercontent.com/wilson1442/vidrun/main/scrollvid.sh"
 WEBROOT="/var/www/html/public_html"
 NGINX_SITE_NAME="vidrun"
 


### PR DESCRIPTION
## Summary
- correct the raw GitHub URL so the installer can download the maintained scrollvid.sh script
- document why the installer must use the /main/ path instead of /refs/heads/main/

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d7410d11bc8322bfea0d3c1a2e893b